### PR TITLE
Tech Art polish pass: layered board ambience + smoother overlay timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ python3 -m http.server 8080
 - Food spawning on empty cells, growth, score tracking
 - Wall/self collision and game-over flow
 - State-aware overlays for Ready / Playing / Paused / Game Over, including concise run summary line
+- Refined visual polish pass: layered board ambience, smoother overlay easing, and subtler HUD typography rhythm
 - Minimal luxury HUD (Score, Best, State + transient helper + active multiplier chip)
 - Contextual touch hint lifecycle (coarse pointer only, auto-dismisses after first successful swipe)
 - Tasteful snake head direction cue for faster recognition at speed

--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,7 @@
   --shadow-soft: 0 6px 24px rgba(0, 0, 0, 0.28);
   --dur-fast: 140ms;
   --dur-med: 240ms;
+  --dur-overlay: 300ms;
   --ease-lux: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -35,7 +36,10 @@ body {
   min-height: 100vh;
   min-height: 100svh;
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-  background: radial-gradient(circle at top, #181f2e 0%, var(--bg) 50%);
+  background:
+    radial-gradient(100% 55% at 14% 2%, rgba(212, 175, 55, 0.08) 0%, rgba(212, 175, 55, 0) 68%),
+    radial-gradient(72% 48% at 88% 6%, rgba(156, 201, 255, 0.07) 0%, rgba(156, 201, 255, 0) 74%),
+    radial-gradient(circle at top, #181f2e 0%, var(--bg) 50%);
   color: var(--text-primary);
 }
 
@@ -67,8 +71,8 @@ body {
 
 .label {
   display: block;
-  font-size: 11px;
-  letter-spacing: 0.36px;
+  font-size: 10.5px;
+  letter-spacing: 0.42px;
   color: var(--text-secondary);
   text-transform: uppercase;
 }
@@ -76,9 +80,10 @@ body {
 .value {
   display: block;
   min-width: 0;
+  margin-top: 1px;
   font-size: clamp(17px, 2.6vw, 22px);
   font-weight: 600;
-  line-height: 1.12;
+  line-height: 1.1;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   overflow: hidden;
@@ -115,10 +120,35 @@ body {
   aspect-ratio: 1 / 1;
   margin: 0 auto;
   overflow: hidden;
+  isolation: isolate;
   touch-action: none;
 }
 
+.board-wrap::before,
+.board-wrap::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.board-wrap::before {
+  z-index: 1;
+  background:
+    radial-gradient(130% 70% at 10% -8%, rgba(212, 175, 55, 0.07) 0%, transparent 62%),
+    radial-gradient(95% 65% at 100% 102%, rgba(255, 255, 255, 0.06) 0%, transparent 70%);
+}
+
+.board-wrap::after {
+  z-index: 3;
+  inset: 1px;
+  border-radius: calc(var(--radius-lg) - 1px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), inset 0 -26px 42px rgba(10, 13, 18, 0.28);
+}
+
 canvas {
+  position: relative;
+  z-index: 2;
   width: 100%;
   height: 100%;
   display: block;
@@ -126,22 +156,24 @@ canvas {
 
 .overlay {
   position: absolute;
+  z-index: 4;
   inset: 0;
   display: grid;
   place-content: center;
   text-align: center;
   gap: var(--space-2);
   padding: var(--space-6);
-  background: color-mix(in srgb, var(--surface) 74%, #000 26%);
+  background: color-mix(in srgb, var(--surface) 66%, #000 34%);
+  backdrop-filter: blur(2px);
   opacity: 0;
-  transform: translateY(8px);
+  transform: translateY(10px) scale(0.992);
   pointer-events: none;
-  transition: opacity var(--dur-med) var(--ease-lux), transform var(--dur-med) var(--ease-lux);
+  transition: opacity var(--dur-overlay) var(--ease-lux), transform var(--dur-overlay) var(--ease-lux);
 }
 
 .overlay.is-visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(0) scale(1);
   pointer-events: auto;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,8 @@ const CONFIG = {
     { score: 28, tickRate: 12 }
   ],
   boardColor: '#141923',
+  boardTintTop: 'rgba(212,175,55,0.045)',
+  boardTintBottom: 'rgba(255,255,255,0.03)',
   snakeBody: '#c4ccd8',
   snakeHead: '#f5f7fa',
   snakeHeadCue: 'rgba(20, 25, 35, 0.82)',
@@ -476,11 +478,27 @@ function drawHeadCue(headCell) {
   ctx.beginPath();
   ctx.arc(cx + ox, cy + oy, Math.max(1.5, cellPx * 0.08), 0, Math.PI * 2);
   ctx.fill();
+
+  ctx.save();
+  ctx.globalAlpha = 0.18;
+  ctx.shadowBlur = Math.max(6, cellPx * 0.3);
+  ctx.shadowColor = 'rgba(245,247,250,0.5)';
+  ctx.beginPath();
+  ctx.arc(cx, cy, Math.max(3.5, cellPx * 0.18), 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(245,247,250,0.42)';
+  ctx.fill();
+  ctx.restore();
 }
 
 function render(interp) {
   ctx.clearRect(0, 0, boardPx, boardPx);
   ctx.fillStyle = CONFIG.boardColor;
+  ctx.fillRect(0, 0, boardPx, boardPx);
+
+  const boardGrad = ctx.createLinearGradient(0, 0, 0, boardPx);
+  boardGrad.addColorStop(0, CONFIG.boardTintTop);
+  boardGrad.addColorStop(1, CONFIG.boardTintBottom);
+  ctx.fillStyle = boardGrad;
   ctx.fillRect(0, 0, boardPx, boardPx);
 
   ctx.strokeStyle = state.gridLineColor;
@@ -495,6 +513,7 @@ function render(interp) {
   const isGold = state.food.kind === 'gold';
   const foodColor = isGold ? CONFIG.goldFoodColor : CONFIG.foodColor;
   const foodGlow = isGold ? CONFIG.goldFoodGlow : CONFIG.foodGlow;
+  const foodPhase = (nowMs() % 1200) / 1200;
 
   ctx.save();
   ctx.translate((state.food.x + 0.5) * cellPx, (state.food.y + 0.5) * cellPx);
@@ -503,6 +522,18 @@ function render(interp) {
   ctx.shadowBlur = isGold ? 22 : 16;
   ctx.shadowColor = foodGlow;
   drawCell(state.food, foodColor, 0.5);
+  ctx.restore();
+
+  ctx.save();
+  const foodCx = (state.food.x + 0.5) * cellPx;
+  const foodCy = (state.food.y + 0.5) * cellPx;
+  const haloRadius = cellPx * (0.34 + foodPhase * 0.18);
+  ctx.globalAlpha = isGold ? 0.24 * (1 - foodPhase) : 0.14 * (1 - foodPhase);
+  ctx.strokeStyle = isGold ? 'rgba(242,214,122,0.9)' : 'rgba(212,175,55,0.75)';
+  ctx.lineWidth = Math.max(1, cellPx * 0.045);
+  ctx.beginPath();
+  ctx.arc(foodCx, foodCy, haloRadius, 0, Math.PI * 2);
+  ctx.stroke();
   ctx.restore();
 
   if (isGold && state.goldExpiresAt > 0) {


### PR DESCRIPTION
## Summary
Small visual-only polish pass focused on luxury clarity and feel (no gameplay rule changes).

### What changed
- Added premium board/background layering treatment (soft ambient tints + subtle board frame depth).
- Smoothed overlay entrance/exit motion with slightly slower luxury easing and gentle scale settle.
- Tuned HUD typography rhythm for cleaner scanability (micro spacing/lettering adjustments).
- Added subtle canvas VFX polish: lightweight board tint gradient, soft head highlight, and restrained food halo pulse.
- Updated README feature list to note this polish behavior.

## Before / After notes
**Before:** Flat board presentation, quicker overlay transition, and more utilitarian HUD cadence.

**After:** Slightly richer premium depth, calmer overlay choreography, and clearer metric hierarchy while preserving existing interaction patterns.

## Manual verification
1. Run locally and load game on desktop + mobile viewport.
2. Confirm gameplay behavior/rules are unchanged (movement, scoring, collisions, pause/resume).
3. Observe board now has subtle layered ambience without reducing readability.
4. Trigger Ready/Pause/Game Over overlays and verify smoother enter/exit timing.
5. Confirm HUD labels/values remain readable at narrow widths (~320px).
6. Confirm no regressions with `prefers-reduced-motion` (transitions remain minimal).
